### PR TITLE
Utilize SteamID64 in the player stats

### DIFF
--- a/lua/fishing_mod/sv_player_stats.lua
+++ b/lua/fishing_mod/sv_player_stats.lua
@@ -55,6 +55,7 @@ local POSITIONS = {
 	-- old fishingmod
 		MIGRATION.legacy = {
 			check = function (ply)
+				if game.SinglePlayer() then return false end
 				return file.IsDir("fishingmod/"..ply:UniqueID(), "DATA")
 			end,
 			read = function (ply)
@@ -112,7 +113,7 @@ local POSITIONS = {
 function fishingmod.LoadPlayerInfo(ply, name)
 	if name then assert(POSITIONS[name], "Unknown data name '"..tostring(name).."'") end
 	
-	if MIGRATION.legacy.check (ply) and not game.SinglePlayer() then
+	if MIGRATION.legacy.check (ply) then
 		Msg ("[fishingmod] ") print ("Can migrate legacy fishingmod data from player: "..tostring(ply).."...")
 		local data = MIGRATION.legacy.read (ply)
 		PrintTable (data)

--- a/lua/fishing_mod/sv_player_stats.lua
+++ b/lua/fishing_mod/sv_player_stats.lua
@@ -72,7 +72,7 @@ local POSITIONS = {
 			end
 		}
 	-- / old fishingmod
-	-- uniqueIDs (broken in singleplayer)
+	-- uniqueIDs
 		MIGRATION.uniqueid = {
 			check = function (ply)
 				local uid = tostring(ply:UniqueID())
@@ -169,7 +169,7 @@ function fishingmod.SavePlayerInfo(ply, name, data)
 	
 	local p_data = fishingmod.LoadPlayerInfo(ply) or {}
 	p_data [name] = data
-
+	
 	local fh = file.Open("fishingmod/"..uid:sub(1,1).."/"..uid..".txt", "wb", "DATA")
 	assert (fh, "Error opening file for player "..tostring(ply))
 	fh:WriteByte(VERSION)

--- a/lua/fishing_mod/sv_player_stats.lua
+++ b/lua/fishing_mod/sv_player_stats.lua
@@ -112,7 +112,7 @@ local POSITIONS = {
 function fishingmod.LoadPlayerInfo(ply, name)
 	if name then assert(POSITIONS[name], "Unknown data name '"..tostring(name).."'") end
 	
-	if MIGRATION.legacy.check (ply) then
+	if MIGRATION.legacy.check (ply) and not game.SinglePlayer() then
 		Msg ("[fishingmod] ") print ("Can migrate legacy fishingmod data from player: "..tostring(ply).."...")
 		local data = MIGRATION.legacy.read (ply)
 		PrintTable (data)


### PR DESCRIPTION
Enables Fishing Mod to be used properly in singleplayer, as UniqueID is broken there.
Also added a migration path from UniqueID.

edit:
Alright, so what actually happens is that because the singleplayer's uniqueID is always 1, the migration check tries to write to fishingmod/1/1.txt.
However, lua does not wait for the file operations to complete. file.Close queues a closure, it doesn't wait for the file to finish writing.
If file.Open is called while the file is being written, it silently fails, and no file handle (fh) is returned (it is nil).

[I've went ahead and gone with another patch to just not run the migration check in SP if you choose not to use SteamID64.](https://github.com/CapsAdmin/fishingmod/pull/1)